### PR TITLE
Fix inconsistency error in list tutorial

### DIFF
--- a/learn/_posts/tutorials/0-01-04-lists.md
+++ b/learn/_posts/tutorials/0-01-04-lists.md
@@ -112,7 +112,7 @@ You can also use a custom function:
 
 ```lisp
 CL-USER> (reduce #'(lambda (a b)
-                     (1- (* a b)))
+                     (* a b))
                  (list 10 20 30))
 6000
 ```


### PR DESCRIPTION
`(1-(* a b))` is not equivalent to `6000` or `(* 10 (* 20 (* 30)))`, `(* a b)` is.