### PR TITLE
Source links on wiki result in 404

### DIFF
--- a/_layouts/wiki-article.html
+++ b/_layouts/wiki-article.html
@@ -9,7 +9,7 @@ layout: wiki
       <a href="{{ page.url }}" class="selected">
         Article
       </a>
-      <a href="https://raw.githubusercontent.com/LispLang/lisplang.github.io/wiki/wiki/_posts/2016-01-01-{{ page.slug }}.md">
+      <a href="https://raw.githubusercontent.com/LispLang/lisplang.github.io/master/{{ page.path }}">
         Source
       </a>
     </div>


### PR DESCRIPTION
All source links on the wiki result in 404 for me. A fix should point them to proper files.