### PR TITLE
Dexador, HTTP client that aims at replacing Drakma

### DIFF
--- a/wiki/_posts/2016-01-01-recommended-libraries.md
+++ b/wiki/_posts/2016-01-01-recommended-libraries.md
@@ -117,6 +117,7 @@ different libraries here)
 # Network
 
 - [Drakma](http://weitz.de/drakma/): HTTP client.
+- [Dexador](http://quickdocs.org/dexador/): HTTp client (that [aims at replacing Drakma](http://www.slideshare.net/fukamachi/dexador-rises)).
 - [usocket](http://common-lisp.net/project/usocket/): Portable socket
   abstraction.
 


### PR DESCRIPTION
but speaking both about Drakma and Dexador leads to a little choice paralysis… should we remove the Drakma line ?