### PR TITLE
fix cl-2dsyntax url (to cliki)

### DIFF
--- a/wiki/_posts/2016-01-01-recommended-libraries.md
+++ b/wiki/_posts/2016-01-01-recommended-libraries.md
@@ -254,7 +254,7 @@ different libraries here)
 - [cl-syntax](https://github.com/m2ym/cl-syntax): Building blocks for extending
   the syntax.
 - [cl-annot](https://github.com/arielnetworks/cl-annot): Decorator syntax.
-- [cl-2dsyntax](http://lisp.hyperprostor.unas.cz/cl-2dsyntax/): Python-like
+- [cl-2dsyntax](http://www.cliki.net/cl-2dsyntax): Python-like
   syntax implemented in reader macros.
 - [named-readtables](https://github.com/melisgl/named-readtables): Separate
   reader macros into packages.


### PR DESCRIPTION
the current link gives a 404, I redirect to Cliki, where it's fixed.