### PR TITLE
editors: note about Portacle

### DIFF
--- a/wiki/_posts/2016-01-01-editors.md
+++ b/wiki/_posts/2016-01-01-editors.md
@@ -11,6 +11,10 @@ for Common Lisp development.
 
 [SLIME][slime] is the most widely-used Common Lisp IDE.
 
+[Portacle](https://shinmera.github.io/portacle/) is a portable and
+multiplatform development environment. It includes Emacs with Slime,
+SBCL, Quicklisp and Git.
+
 ## Sly
 
 [Sly][sly] is a fork of SLIME.


### PR DESCRIPTION
adding Portacle in the Emacs section (a portable and multiplatform environment with Emacs25 nicely configured, Slime, Quicklisp, SBCL and Git). 

Easiest way to getting started.

It says it isn't officially released because the package doesn't work well on the latest MacOS. It's perfect on linux and reported to work on windows.