### PR TITLE
wiki index: rm double reader-macros entry

### DIFF
--- a/wiki/index.html
+++ b/wiki/index.html
@@ -31,9 +31,6 @@ permalink: /wiki/
 
     <ul>
       <li>
-        <a href="/wiki/article/reader-macros">Reader Macros</a>
-      </li>
-      <li>
         <a href="/books/">Common Lisp books</a>
       </li>
       <li>


### PR DESCRIPTION
I just removed the wiki entry on reader macros that was there twice.