### PR TITLE
Replace Atom-Slime with SLIMA in editors list

### DIFF
--- a/wiki/_posts/2016-01-01-editors.md
+++ b/wiki/_posts/2016-01-01-editors.md
@@ -42,9 +42,9 @@ for Vim.
 
 # Atom
 
-## Atom-slime
+## SLIMA
 
-[Atom-Slime](https://atom.io/packages/atom-slime) is a SLIME plugin to
+[SLIMA](https://atom.io/packages/slima) is a SLIME plugin to
 interactively write Common Lisp with Atom, helping turn Atom into a
 full-featured Lisp IDE.
 


### PR DESCRIPTION
Atom-Slime is no longer maintained (see right under the image in the readme: https://github.com/sjlevine/atom-slime). [SLIMA](https://atom.io/packages/slima) is the maintained fork.