### PR TITLE
style: fix clos documentation indentation

### DIFF
--- a/learn/_posts/tutorials/2018-01-07-clos.md
+++ b/learn/_posts/tutorials/2018-01-07-clos.md
@@ -43,7 +43,7 @@ CL-USER> (description 3.14)
   ((speed :accessor vehicle-speed
           :initarg :speed
           :type real
-	      :documentation "The vehicle's current speed."))
+          :documentation "The vehicle's current speed."))
   (:documentation "The base class of vehicles."))
 ```
 


### PR DESCRIPTION
This change fixes the indentation of the example :documentation.