### PR TITLE
style: :type slots are checked by CCL and SBCL 1.5.9

### DIFF
--- a/style.md
+++ b/style.md
@@ -238,6 +238,11 @@ slots.
 
 Here, the [trivial-types][tt] library will come in handy.
 
+Checking that the type complies to the initial value is undefined by
+the standard and left to the implementations. Clozure CL and SBCL
+1.5.9 and onwards (or all versions when safety is high) do type checks
+at compile time.
+
 # Flow Control
 
 In short:


### PR DESCRIPTION
Hello,

a bit more of information, following SBCL 1.5.9 that does static type checks for :type slots.

https://bugs.launchpad.net/sbcl/+bug/1850423

and there is apparently more in SBCL 2.0.

