### PR TITLE
correct parenthesis in reduce example

### DIFF
--- a/learn/_posts/tutorials/2018-01-04-lists.md
+++ b/learn/_posts/tutorials/2018-01-04-lists.md
@@ -117,7 +117,7 @@ CL-USER> (reduce #'(lambda (a b)
 6000
 ```
 
-The above is equivalent to `(* 10 (* 20 (* 30)))`. To get a better understanding
+The above is equivalent to `(* (* 10 20) 30)`. To get a better understanding
 of how reduce works, we can use `format`:
 
 ```lisp


### PR DESCRIPTION
The parenthesis in the explanation were written as if reduce is a right fold, but it is a left fold.

Fixes https://github.com/LispLang/lisplang.github.io/issues/73