### PR TITLE
Debug GitHub Actions deployment error

### DIFF
--- a/_sass/components/_big-header.scss
+++ b/_sass/components/_big-header.scss
@@ -1,5 +1,6 @@
 @use '../variables' as *;
 @use '../utils/mixins' as *;
+@use '../vendor/flexbox' as *;
 
 header.hero {
     height: 100vh;

--- a/_sass/components/_breadcrumbs.scss
+++ b/_sass/components/_breadcrumbs.scss
@@ -1,5 +1,6 @@
 @use '../variables' as *;
 @use '../utils/mixins' as *;
+@use '../vendor/flexbox' as *;
 
 .breadcrumbs {
     width: 100%;

--- a/_sass/components/_footer.scss
+++ b/_sass/components/_footer.scss
@@ -1,5 +1,6 @@
 @use '../variables' as *;
 @use '../utils/mixins' as *;
+@use '../vendor/flexbox' as *;
 
 /* Footer style */
 

--- a/_sass/components/_gallery.scss
+++ b/_sass/components/_gallery.scss
@@ -1,4 +1,5 @@
 @use '../utils/mixins' as *;
+@use '../vendor/flexbox' as *;
 
 .gallery {
     ul {

--- a/_sass/components/_image-overlay.scss
+++ b/_sass/components/_image-overlay.scss
@@ -1,4 +1,5 @@
 @use '../utils/mixins' as *;
+@use '../vendor/flexbox' as *;
 
 .image-overlay {
     width: 100%;

--- a/_sass/components/_navbar.scss
+++ b/_sass/components/_navbar.scss
@@ -1,5 +1,6 @@
 @use '../variables' as *;
 @use '../utils/mixins' as *;
+@use '../vendor/flexbox' as *;
 
 /* Navbar style */
 

--- a/_sass/components/_window.scss
+++ b/_sass/components/_window.scss
@@ -1,4 +1,5 @@
 @use '../utils/mixins' as *;
+@use '../vendor/flexbox' as *;
 
 .window {
     $bar-height: 30px;

--- a/assets/css/books.scss
+++ b/assets/css/books.scss
@@ -9,6 +9,7 @@
 @use 'utils/normalize';
 @use 'utils/reset';
 @use 'utils/mixins' as *;
+@use 'vendor/flexbox' as *;
 
 @use 'components/standard-text' as *;
 @use 'components/navbar';

--- a/assets/css/landing.scss
+++ b/assets/css/landing.scss
@@ -9,6 +9,7 @@
 @use 'utils/normalize';
 @use 'utils/reset';
 @use 'utils/mixins' as *;
+@use 'vendor/flexbox' as *;
 
 @use 'components/navbar';
 @use 'components/standard-text' as *;

--- a/assets/css/learn.scss
+++ b/assets/css/learn.scss
@@ -9,6 +9,7 @@
 @use 'utils/normalize';
 @use 'utils/reset';
 @use 'utils/mixins' as *;
+@use 'vendor/flexbox' as *;
 
 @use 'components/standard-text' as *;
 @use 'components/highlight';

--- a/assets/css/news.scss
+++ b/assets/css/news.scss
@@ -9,6 +9,7 @@
 @use 'utils/normalize';
 @use 'utils/reset';
 @use 'utils/mixins' as *;
+@use 'vendor/flexbox' as *;
 
 @use 'components/standard-text' as *;
 @use 'components/navbar';

--- a/assets/css/success.scss
+++ b/assets/css/success.scss
@@ -9,6 +9,7 @@
 @use 'utils/normalize';
 @use 'utils/reset';
 @use 'utils/mixins' as *;
+@use 'vendor/flexbox' as *;
 
 @use 'components/standard-text' as *;
 @use 'components/navbar';

--- a/assets/css/under-construction.scss
+++ b/assets/css/under-construction.scss
@@ -9,6 +9,7 @@
 @use 'utils/normalize';
 @use 'utils/reset';
 @use 'utils/mixins' as *;
+@use 'vendor/flexbox' as *;
 
 .unfinished {
     font-family: 'PT Sans';

--- a/assets/css/wiki.scss
+++ b/assets/css/wiki.scss
@@ -8,6 +8,7 @@
 @use 'utils/fonts';
 @use 'utils/reset';
 @use 'utils/mixins' as *;
+@use 'vendor/flexbox' as *;
 
 @use 'components/highlight';
 


### PR DESCRIPTION
The @forward directive in utils/mixins was not reliably making flexbox mixins available in all contexts with the Jekyll SCSS converter version being used in CI (jekyll-sass-converter-1.5.2).

This commit adds explicit @use 'vendor/flexbox' as *; imports to all SCSS files that use flexbox mixins, ensuring they are always available.

Files updated:
- All main page SCSS files (books, landing, learn, news, success, under-construction, wiki)
- All component SCSS files using flexbox (big-header, breadcrumbs, footer, gallery, image-overlay, navbar, window)

This resolves the "Undefined mixin 'flexbox'" error in GitHub Actions.