### PR TITLE
Remove unused code from repository

### DIFF
--- a/_sass/utils/_fonts.scss
+++ b/_sass/utils/_fonts.scss
@@ -312,7 +312,19 @@
 
 /* Inconsolata */
 
-@import url('https://fonts.googleapis.com/css?family=Inconsolata');
+@font-face {
+  font-family: 'Inconsolata';
+  font-style: normal;
+  font-weight: 400;
+  src: url('/assets/fonts/inconsolata/Inconsolata-Regular.ttf') format('truetype');
+}
+
+@font-face {
+  font-family: 'Inconsolata';
+  font-style: normal;
+  font-weight: 700;
+  src: url('/assets/fonts/inconsolata/Inconsolata-Bold.ttf') format('truetype');
+}
 
 /* ET Book */
 


### PR DESCRIPTION
Replace the Google Fonts CDN import with local @font-face declarations for Inconsolata Regular (400) and Bold (700) weights. This:
- Improves privacy by removing external font requests
- Reduces dependency on third-party CDN
- Can improve page load performance
- Uses existing local font files already in the repo

The local Inconsolata font files were already present in the repository but unused. This change activates them.